### PR TITLE
Support lambda function (any), fixed typos, added unit tests

### DIFF
--- a/apply_parser.go
+++ b/apply_parser.go
@@ -1,0 +1,6 @@
+package godata
+
+func ParseApplyString(apply string) (*GoDataApplyQuery, error) {
+	result := GoDataApplyQuery(apply)
+	return &result, nil
+}

--- a/filter_parser.go
+++ b/filter_parser.go
@@ -5,6 +5,7 @@ const (
 	FilterTokenCloseParen
 	FilterTokenWhitespace
 	FilterTokenNav
+	FilterTokenColon // for 'any' and 'all' lambda operators
 	FilterTokenComma
 	FilterTokenLogical
 	FilterTokenOp
@@ -51,6 +52,7 @@ func FilterTokenizer() *Tokenizer {
 	t.Add("^\\(", FilterTokenOpenParen)
 	t.Add("^\\)", FilterTokenCloseParen)
 	t.Add("^/", FilterTokenNav)
+	t.Add("^:", FilterTokenColon)
 	t.Add("^,", FilterTokenComma)
 	t.Add("^(eq|ne|gt|ge|lt|le|and|or|not|has)", FilterTokenLogical)
 	t.Add("^(add|sub|mul|div|mod)", FilterTokenOp)

--- a/filter_parser.go
+++ b/filter_parser.go
@@ -92,7 +92,7 @@ func FilterParser() *Parser {
 	parser.DefineOperator("le", 2, OpAssociationLeft, 4)
 	parser.DefineOperator("isof", 2, OpAssociationLeft, 4)
 	parser.DefineOperator("eq", 2, OpAssociationLeft, 3)
-	parser.DefineOperator("nq", 2, OpAssociationLeft, 3)
+	parser.DefineOperator("ne", 2, OpAssociationLeft, 3)
 	parser.DefineOperator("and", 2, OpAssociationLeft, 2)
 	parser.DefineOperator("or", 2, OpAssociationLeft, 1)
 	parser.DefineFunction("contains", 2)

--- a/filter_parser.go
+++ b/filter_parser.go
@@ -97,6 +97,7 @@ func FilterParser() *Parser {
 	parser.DefineOperator("ne", 2, OpAssociationLeft, 3)
 	parser.DefineOperator("and", 2, OpAssociationLeft, 2)
 	parser.DefineOperator("or", 2, OpAssociationLeft, 1)
+	parser.DefineOperator(":", 2, OpAssociationLeft, 1)
 	parser.DefineFunction("contains", 2)
 	parser.DefineFunction("endswith", 2)
 	parser.DefineFunction("startswith", 2)

--- a/filter_parser_test.go
+++ b/filter_parser_test.go
@@ -6,6 +6,68 @@ import (
 	"testing"
 )
 
+func TestFilterAny(t *testing.T) {
+	tokenizer := FilterTokenizer()
+	input := "Tags/any(d:d/Key eq 'Site' and d/Value lt 10)"
+	expect := []*Token{
+		&Token{Value: "Tags", Type: FilterTokenLiteral},
+		&Token{Value: "/", Type: FilterTokenNav},
+		&Token{Value: "any", Type: FilterTokenLambda},
+		&Token{Value: "(", Type: FilterTokenOpenParen},
+		&Token{Value: "d", Type: FilterTokenLiteral},
+		&Token{Value: ":", Type: FilterTokenColon},
+		&Token{Value: "d", Type: FilterTokenLiteral},
+		&Token{Value: "/", Type: FilterTokenNav},
+		&Token{Value: "Key", Type: FilterTokenLiteral},
+		&Token{Value: "eq", Type: FilterTokenLogical},
+		&Token{Value: "'Site'", Type: FilterTokenString},
+		&Token{Value: "and", Type: FilterTokenLogical},
+		&Token{Value: "d", Type: FilterTokenLiteral},
+		&Token{Value: "/", Type: FilterTokenNav},
+		&Token{Value: "Value", Type: FilterTokenLiteral},
+		&Token{Value: "lt", Type: FilterTokenLogical},
+		&Token{Value: "10", Type: FilterTokenInteger},
+		&Token{Value: ")", Type: FilterTokenCloseParen},
+	}
+	output, err := tokenizer.Tokenize(input)
+	if err != nil {
+		t.Error(err)
+	}
+
+	result, err := CompareTokens(expect, output)
+	if !result {
+		t.Error(err)
+	}
+}
+
+func TestFilterAll(t *testing.T) {
+	tokenizer := FilterTokenizer()
+	input := "Tags/all(d:d/Key eq 'Site')"
+	expect := []*Token{
+		&Token{Value: "Tags", Type: FilterTokenLiteral},
+		&Token{Value: "/", Type: FilterTokenNav},
+		&Token{Value: "all", Type: FilterTokenLambda},
+		&Token{Value: "(", Type: FilterTokenOpenParen},
+		&Token{Value: "d", Type: FilterTokenLiteral},
+		&Token{Value: ":", Type: FilterTokenColon},
+		&Token{Value: "d", Type: FilterTokenLiteral},
+		&Token{Value: "/", Type: FilterTokenNav},
+		&Token{Value: "Key", Type: FilterTokenLiteral},
+		&Token{Value: "eq", Type: FilterTokenLogical},
+		&Token{Value: "'Site'", Type: FilterTokenString},
+		&Token{Value: ")", Type: FilterTokenCloseParen},
+	}
+	output, err := tokenizer.Tokenize(input)
+	if err != nil {
+		t.Error(err)
+	}
+
+	result, err := CompareTokens(expect, output)
+	if !result {
+		t.Error(err)
+	}
+}
+
 func TestFilterTokenizer(t *testing.T) {
 
 	tokenizer := FilterTokenizer()

--- a/inlinecount_parser.go
+++ b/inlinecount_parser.go
@@ -1,0 +1,17 @@
+package godata
+
+const (
+	ALLPAGES = "allpages"
+	NONE     = "none"
+)
+
+func ParseInlineCountString(inlinecount string) (*GoDataInlineCountQuery, error) {
+	result := GoDataInlineCountQuery(inlinecount)
+	if inlinecount == ALLPAGES {
+		return &result, nil
+	} else if inlinecount == NONE {
+		return &result, nil
+	} else {
+		return nil, BadRequestError("Could not parse orderby query.")
+	}
+}

--- a/inlinecount_parser.go
+++ b/inlinecount_parser.go
@@ -12,6 +12,6 @@ func ParseInlineCountString(inlinecount string) (*GoDataInlineCountQuery, error)
 	} else if inlinecount == NONE {
 		return &result, nil
 	} else {
-		return nil, BadRequestError("Could not parse orderby query.")
+		return nil, BadRequestError("Invalid inlinecount query.")
 	}
 }

--- a/orderby_parser.go
+++ b/orderby_parser.go
@@ -23,12 +23,14 @@ func ParseOrderByString(orderby string) (*GoDataOrderByQuery, error) {
 		parts := strings.Split(v, " ")
 		field := &Token{Value: parts[0]}
 		var order string = ASC
-		if strings.ToLower(parts[0]) == ASC {
-			order = ASC
-		} else if strings.ToLower(parts[1]) == DESC {
-			order = DESC
-		} else {
-			return nil, BadRequestError("Could not parse orderby query.")
+		if len(parts) > 1 {
+			if strings.ToLower(parts[1]) == ASC {
+				order = ASC
+			} else if strings.ToLower(parts[1]) == DESC {
+				order = DESC
+			} else {
+				return nil, BadRequestError("Could not parse orderby query.")
+			}
 		}
 		result = append(result, &OrderByItem{field, order})
 	}

--- a/parser.go
+++ b/parser.go
@@ -180,7 +180,7 @@ func (p *Parser) InfixToPostfix(tokens []*Token) (*tokenQueue, error) {
 			}
 			// pop off open paren
 			stack.Pop()
-			// if next token is a funciton, move it to the queue
+			// if next token is a function, move it to the queue
 			if !stack.Empty() {
 				if _, ok := p.Functions[stack.Peek().Value]; ok {
 					queue.Enqueue(stack.Pop())

--- a/request_model.go
+++ b/request_model.go
@@ -65,6 +65,7 @@ type GoDataSegment struct {
 
 type GoDataQuery struct {
 	Filter      *GoDataFilterQuery
+	Apply       *GoDataApplyQuery
 	Expand      *GoDataExpandQuery
 	Select      *GoDataSelectQuery
 	OrderBy     *GoDataOrderByQuery
@@ -82,6 +83,8 @@ type GoDataQuery struct {
 type GoDataFilterQuery struct {
 	Tree *ParseNode
 }
+
+type GoDataApplyQuery string
 
 type GoDataExpandQuery struct {
 	ExpandItems []*ExpandItem

--- a/request_model.go
+++ b/request_model.go
@@ -64,15 +64,16 @@ type GoDataSegment struct {
 }
 
 type GoDataQuery struct {
-	Filter  *GoDataFilterQuery
-	Expand  *GoDataExpandQuery
-	Select  *GoDataSelectQuery
-	OrderBy *GoDataOrderByQuery
-	Top     *GoDataTopQuery
-	Skip    *GoDataSkipQuery
-	Count   *GoDataCountQuery
-	Search  *GoDataSearchQuery
-	Format  *GoDataFormatQuery
+	Filter      *GoDataFilterQuery
+	Expand      *GoDataExpandQuery
+	Select      *GoDataSelectQuery
+	OrderBy     *GoDataOrderByQuery
+	Top         *GoDataTopQuery
+	Skip        *GoDataSkipQuery
+	Count       *GoDataCountQuery
+	InlineCount *GoDataInlineCountQuery
+	Search      *GoDataSearchQuery
+	Format      *GoDataFormatQuery
 }
 
 // Stores a parsed version of the filter query string. Can be used by
@@ -99,6 +100,8 @@ type GoDataTopQuery int
 type GoDataSkipQuery int
 
 type GoDataCountQuery bool
+
+type GoDataInlineCountQuery string
 
 type GoDataSearchQuery struct {
 	Tree *ParseNode

--- a/url_parser.go
+++ b/url_parser.go
@@ -206,6 +206,7 @@ func SemanticizePathSegment(segment *GoDataSegment, service *GoDataService) erro
 
 func ParseUrlQuery(query url.Values) (*GoDataQuery, error) {
 	filter := query.Get("$filter")
+	apply := query.Get("$apply")
 	expand := query.Get("$expand")
 	sel := query.Get("$select")
 	orderby := query.Get("$orderby")
@@ -221,6 +222,12 @@ func ParseUrlQuery(query url.Values) (*GoDataQuery, error) {
 	var err error = nil
 	if filter != "" {
 		result.Filter, err = ParseFilterString(filter)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if apply != "" {
+		result.Apply, err = ParseApplyString(apply)
 	}
 	if err != nil {
 		return nil, err

--- a/url_parser.go
+++ b/url_parser.go
@@ -212,6 +212,7 @@ func ParseUrlQuery(query url.Values) (*GoDataQuery, error) {
 	top := query.Get("$top")
 	skip := query.Get("$skip")
 	count := query.Get("$count")
+	inlinecount := query.Get("$inlinecount")
 	search := query.Get("$search")
 	format := query.Get("$format")
 
@@ -256,6 +257,12 @@ func ParseUrlQuery(query url.Values) (*GoDataQuery, error) {
 	}
 	if count != "" {
 		result.Count, err = ParseCountString(count)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if inlinecount != "" {
+		result.InlineCount, err = ParseInlineCountString(inlinecount)
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- Fixed the "Not Equal" operator, which is "ne" as specified in the OData spec, not "nq".
- Added support for "any" and "all" lambda function.
- Added unit tests for nested path and lambda functions. Added colon operator (:) for lambda functions.
- Fixed minor typos.